### PR TITLE
Use twigjs-loader instead of twig-loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+/node_modules/

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "mini-css-extract-plugin": "^0.8",
         "postcss-loader": "^3.0",
         "sass-loader": "^7.1",
-        "twigjs-loader": "github:leviy/twigjs-loader#twigpath-loader-option",
+        "twigjs-loader": "^1.0",
         "webpack-config": "^7.5",
         "webpack-manifest-plugin": "^2.0"
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "mini-css-extract-plugin": "^0.8",
         "postcss-loader": "^3.0",
         "sass-loader": "^7.1",
-        "twig-loader": "^0.5",
+        "twigjs-loader": "^0.2.2",
         "webpack-config": "^7.5",
         "webpack-manifest-plugin": "^2.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@leviy/webpack-config-default",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "repository": {
         "type": "git",
         "url": "git+ssh://git@github.com:leviy/webpack-config-default.git"
@@ -14,7 +14,7 @@
         "mini-css-extract-plugin": "^0.8",
         "postcss-loader": "^3.0",
         "sass-loader": "^7.1",
-        "twigjs-loader": "^0.2.2",
+        "twigjs-loader": "github:leviy/twigjs-loader#twigpath-loader-option",
         "webpack-config": "^7.5",
         "webpack-manifest-plugin": "^2.0"
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,14 @@ module.exports = new Config().defaults({
                 test: /\.twig$/,
                 loader: 'twigjs-loader',
                 options: {
-                    twigPath: path.resolve(process.cwd(), 'node_modules/twig'),
+                    renderTemplate(twigData, dependencies) {
+                        return `
+                            ${dependencies}
+                            var twig = require('${path.resolve(process.cwd(), 'node_modules/twig')}').twig;
+                            var tpl = twig(${JSON.stringify(twigData)});
+                            module.exports = function(context) { return tpl.render(context); };
+                        `;
+                    },
                 },
             },
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = new Config().defaults({
         rules: [
             {
                 test: /\.twig$/,
-                loader: 'twig-loader',
+                loader: 'twigjs-loader',
             },
             {
                 test: /\.js$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const { Config, environment } = require('webpack-config');
 
+const path = require('path');
 const webpack = require('webpack');
 
 const ManifestPlugin = require('webpack-manifest-plugin');
@@ -31,6 +32,9 @@ module.exports = new Config().defaults({
             {
                 test: /\.twig$/,
                 loader: 'twigjs-loader',
+                options: {
+                    twigPath: path.resolve(process.cwd(), 'node_modules/twig'),
+                },
             },
             {
                 test: /\.js$/,


### PR DESCRIPTION
In this package (based on twig-loader) the issue with using aliases such as "@base" is resolved.

- [ ] The pull request is complete according to the [Definition of Done](https://sites.google.com/leviy.com/development/development/definition-of-done)
  - [ ] Acceptance criteria in the ticket have been met
  - [ ] Automated tests are written according to the [test plan](https://docs.google.com/document/d/106bwyTS-gIrT7edLW4_5pCl6DSDaZBEMiiyBw1za0R8/edit#heading=h.5ybg7xjjzlkj)
  - [ ] The documentation is up-to-date
  - [ ] Deployment automation includes newly introduced environment variables and credentials are added to the credentials.fact file of all servers
- [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] When applicable, the pull request title starts with the issue number
